### PR TITLE
Check the 'Van deze verkoper' checkbox when on a seller overview page

### DIFF
--- a/JustTheSearchResults.user.js
+++ b/JustTheSearchResults.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Marktplaats; enkel de zoekresultaten.
-// @version        1.4.2
+// @version        1.4.3
 // @namespace      Marktplaats
 // @description    * Verbergt bedrijf/webshop advertenties
 // @description    * Verbergt betaalde advertenties
@@ -42,6 +42,12 @@ function alterSearchbar () {
   $('div.mp-Header.mp-text-paragraph.mp-cloak').addClass('mp-Header--expandSearchBar')
 }
 waitForKeyElements('header.u-stickyHeader div.mp-Header.mp-text-paragraph.mp-cloak', alterSearchbar)
+
+function alterSellerOverviewSearch () {
+  // When searching on a seller's overview page (Meer advertenties), automatically select 'Van deze verkoper' when using the searchbar
+  $('input[name*=\'searchOnPage\']').prop('checked', true)
+}
+waitForKeyElements('input[name*=\'searchOnPage\']', alterSellerOverviewSearch, true)
 
 function alterSearchResults () {
   // Verberg betaalde advertenties en bedrijven


### PR DESCRIPTION
When on a overview page of a seller, the 'Van deze verkoper' checkbox needs to be checked in order to continue searching on the seller's overview page.

This MR changes the default behavior so that that checkbox is checked by default.